### PR TITLE
Use JSON.stringify() to avoid character escaping issue.

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ http.createServer(function(request, response) {
 			response.writeHead(200);
 			if (msgHash === auth) {
 				var receivedMsg = JSON.parse(payload);
-				var responseMsg = '{ "type": "message", "text": "You typed: ' + receivedMsg.text + '" }';	
+				var responseMsg = JSON.stringify({ type: "message", text: "You typed: '" + receivedMsg.text + "'" });	
 			} else {
 				var responseMsg = '{ "type": "message", "text": "Error: message sender cannot be authenticated." }';
 			}


### PR DESCRIPTION
When a user inputs a link like the following screenshot, concatenating the json string does not handle it properly.

![image](https://user-images.githubusercontent.com/11069971/42093184-ccb09494-7bee-11e8-9f5a-a65a5ee018b5.png)
